### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.6",
   "description": "Four amazing games for your Brain",
   "keywords": [
-  "play for brain",
-  "greatest common fivisor",
-  "prime numbers",
-  "progression"
+    "play for brain",
+    "greatest common fivisor",
+    "prime numbers",
+    "progression"
   ],
   "author": "Sergey Saramud",
   "email": "s.saramud@gmail.com",


### PR DESCRIPTION

Hello Saramud!

It seems like you have npm as one of your (dev-) dependency in frontend-project-lvl1.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
